### PR TITLE
Adding necessary file to keep Custom Domain

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+bcalhelp.dev


### PR DESCRIPTION
The Hugo system uses a /static path to copy files directly as part of building.  GitHub Pages looks for a "CNAME" file with only the Custom Domain as contents in the branch for GitHub Pages, which Hugo recreates on commits to main.

This PR adds the CNAME file to the /Static path to preserve the GH pages file on Hugo regeneration.